### PR TITLE
REVERT: SMoraisAnsys manuel addition to maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,4 +56,3 @@ extra:
     - MaxJPRey
     - maxcapodi78
     - Samuelopez-ansys
-    - SMoraisAnsys


### PR DESCRIPTION
Reverting the previous change after seeing that the documentation provides a way to add someone through and issue, see https://conda-forge.org/docs/maintainer/updating_pkgs/#updating-the-maintainer-list. Removing my name from the list will probably avoid conflicts when I get added through an issue.